### PR TITLE
Update the hyperlink to test_vector_handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ limits.
 # New Vectors
 
 The contents of `vectors/full-message-decrypt` conform to the new rules for test vectors.
-An implementation of these rules can be found [here](https://github.com/aws/aws-encryption-sdk-python/tree/master/test_vector_generator)
+An implementation of these rules can be found [here](https://github.com/aws/aws-encryption-sdk-python/tree/master/test_vector_handlers)
 and this readme will be updated soon once the rules themselves are published.


### PR DESCRIPTION
The hyperlink https://github.com/aws/aws-encryption-sdk-python/tree/master/test_vector_generator  to the implementation of test-vector-rules seems to be broken, due to a name change from test_vector_generators to test_vector_handlers. 